### PR TITLE
chore: clean up for python doc release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="smile_id_core",
-    version="1.0.6",
+    version="1.0.7",
     description="The official Smile Identity package exposes four classes namely; the WebApi class, the IDApi class, the Signature class and the Utilities class.",
     packages=find_packages(exclude=["*.tests", "*.tests.*"]),
     long_description=long_description,

--- a/smile_id_core/Utilities.py
+++ b/smile_id_core/Utilities.py
@@ -34,7 +34,7 @@ class Utilities:
 
         validate_sec_params(sec_params)
         # validate_partner_param throws an error if job_id is empty/not provided,
-        # but it's not required by get_kob_status
+        # but it's not required by get_job_status
         Utilities.validate_partner_params({**partner_params, "job_id": partner_params.get("job_id", "job_id")})
         if not option_params or option_params is None:
             options = {

--- a/smile_id_core/Utilities.py
+++ b/smile_id_core/Utilities.py
@@ -33,9 +33,9 @@ class Utilities:
             )
 
         validate_sec_params(sec_params)
-        # validate_partner_param throws an error if job_id is empty/not provided,
+        # validate_partner_param throws an error if job_type is empty/not provided,
         # but it's not required by get_job_status
-        Utilities.validate_partner_params({**partner_params, "job_id": partner_params.get("job_id", "job_id")})
+        Utilities.validate_partner_params({**partner_params, "job_type": partner_params.get("job_type", "job_type")})
         if not option_params or option_params is None:
             options = {
                 "return_job_status": True,

--- a/smile_id_core/Utilities.py
+++ b/smile_id_core/Utilities.py
@@ -26,14 +26,16 @@ class Utilities:
         else:
             self.url = sid_server
 
-    def get_job_status(self, partner_params, option_params, sec_params):
+    def get_job_status(self, partner_params, option_params, sec_params=None):
         if sec_params is None:
             sec_params = get_signature(
                 self.partner_id, self.api_key, option_params.get("signature")
             )
 
         validate_sec_params(sec_params)
-        Utilities.validate_partner_params(partner_params)
+        # validate_partner_param throws an error if job_id is empty/not provided,
+        # but it's not required by get_kob_status
+        Utilities.validate_partner_params({**partner_params, "job_id": partner_params.get("job_id", "job_id")})
         if not option_params or option_params is None:
             options = {
                 "return_job_status": True,


### PR DESCRIPTION
This PR makes the `job_id` and `sec_param` optional in `Utilities.get_job_status`