### PR TITLE
Version update

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,10 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
+## [Unreleased] - 2022-10-19
+## Changed
+  * Moved information of python version to the class initialization.
 
 ## [0.0.13] - 2020-09-16
 ### Added
   * Created changelog
   * Fixed job status error string format
-  * Added black for code  formatting
+  * Added black for code formatting
   * Fixed python semantics
   * Moved zipfile out from webapi class

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+version = attr: smile_id_core.__version__

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="smile_id_core",
-    version="1.0.8",
     description="The official Smile Identity package exposes four classes namely; the WebApi class, the IDApi class, the Signature class and the Utilities class.",
     packages=find_packages(exclude=["*.tests", "*.tests.*"]),
     long_description=long_description,

--- a/smile_id_core/__init__.py
+++ b/smile_id_core/__init__.py
@@ -1,7 +1,10 @@
+# from ._version import __version__
 from smile_id_core.Utilities import Utilities
 from smile_id_core.IdApi import IdApi
 from smile_id_core.WebApi import WebApi
 from smile_id_core.Signature import Signature
 from smile_id_core.ServerError import ServerError
 
+__version__ = "1.0.8"
 __all__ = ["IdApi", "Signature", "Utilities", "WebApi", "ServerError"]
+

--- a/smile_id_core/__init__.py
+++ b/smile_id_core/__init__.py
@@ -1,4 +1,3 @@
-# from ._version import __version__
 from smile_id_core.Utilities import Utilities
 from smile_id_core.IdApi import IdApi
 from smile_id_core.WebApi import WebApi
@@ -7,4 +6,3 @@ from smile_id_core.ServerError import ServerError
 
 __version__ = "1.0.8"
 __all__ = ["IdApi", "Signature", "Utilities", "WebApi", "ServerError"]
-

--- a/tests/setup_config_test.py
+++ b/tests/setup_config_test.py
@@ -1,0 +1,13 @@
+"""
+This test suite contains different test around testing different setup configurations
+for the core library.
+"""
+import unittest
+from smile_id_core import __version__
+
+
+class SetupConfigTest(
+    unittest.TestCase,
+):
+    def test_version_exists(self):
+        self.assertIsNotNone(__version__, "Package version is not defined.")


### PR DESCRIPTION
Previously, the version information for the package was defined on the setup file. I'm adding this small fix to add a configuration file to this package, along with moving versioning information.

Tested by running the entire test suite.