### PR TITLE
fix github action trigger

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,8 +2,9 @@
 # workflow and should be the same as the version number in the pyproject.toml file.
 name: Publish to PyPI
 on:
-  tags: # run on tags starting with a v character. ex. v1.0.0
-    - v*
+  push:
+    tags: # run on tags starting with a v character. ex. v1.0.0
+      - v*
 jobs:
   test:
     uses: ./.github/workflows/test.yml


### PR DESCRIPTION
#15 introduced a github action to publish the package to pypi. @vanshg correctly pointed out in https://github.com/smileidentity/smile-identity-core-python-3/pull/15#discussion_r1010964593 that the trigger was misconfigured. This corrects the trigger syntax. 