### PR TITLE
skip publish steps if tag already exists 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,17 +28,24 @@ jobs:
         id: get_version
         run: echo "::set-output name=version::$(poetry version --short)"
       - name: check if git tag exists
+        id: check_tag
         run: |
           git fetch --tags
           if git tag -l ${{ steps.get_version.outputs.version }}; then
             echo "git tag already exists"
-            exit 0
+            echo "::set-output name=publish::false"
+          else
+            echo "git tag does not exist"
+            echo "::set-output name=publish::true"
           fi
       - name: create git tag
+        if: steps.check_tag.outputs.publish == 'true'
         run: git tag ${{ steps.get_version.outputs.version }}
       - name: push git tag
+        if: steps.check_tag.outputs.publish == 'true'
         run: git push --tags
       - name: build and publish to pypi
+        if: steps.check_tag.outputs.publish == 'true'
         run : poetry publish --build --username $PYPI_USERNAME --password $PYPI_TOKEN
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,14 +8,14 @@ readme = "README.md"
 homepage = "https://github.com/smileidentity/smile-identity-core-python-3"
 classifiers = [
     "License :: OSI Approved :: MIT License",
-    "Operating System :: OS Independent"
+    "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.11"
 ]
 packages = [{ include = "smile_id_core" }]
 exclude = ["tests/**/*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,8 @@ authors = ["Smile Identity <support@smileidentity.com>"]
 readme = "README.md"
 homepage = "https://github.com/smileidentity/smile-identity-core-python-3"
 classifiers = [
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent"
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
@@ -14,8 +16,6 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
-    "License :: OSI Approved :: MIT License",
-    "Operating System :: OS Independent"
 ]
 packages = [{ include = "smile_id_core" }]
 exclude = ["tests/**/*"]


### PR DESCRIPTION
github does not abort workflows on `exit 0`. This skips the publish steps if a tag already exists. 