### PR TITLE
Fix ci error 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
       - main
     paths:
       - pyproject.toml
+  workflow_dispatch:
 permissions:
   contents: write
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           cache: 'poetry'
+          python-version: '3.11'
       - name: Install dependencies
         run: poetry install --only main
       - name: get cvml package version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "smile-id-core"
 version = "2.0.1"
-description = "The official Smile Identity package exposes four classes namely; the WebApi class, the IDApi class, the Signature class and the Utilities class."
+description = "The official Smile Identity package exposes four classes. WebApi, IDApi, Signature, and Utilities."
 license = "MIT"
 authors = ["Smile Identity <support@smileidentity.com>"]
 readme = "README.md"


### PR DESCRIPTION
The publish ci action does not specify a python version, which causes the caching mechanism to fail. See [here](https://github.com/actions/setup-python/issues/475) for more information. This sets a version. Additionally, it adds a workflow dispatch trigger, so we don't have to change pyproject.toml every time we want to run the publish workflow. 