### PR TITLE
Update Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,11 +3,15 @@ updates:
 - package-ecosystem: pip
   directory: /
   schedule:
-    interval: weekly
+    interval: monthly
+    day: wednesday
+    time: '15:00'
 - package-ecosystem: github-actions
   directory: /
   schedule:
-    cron: 0 16 12 * *
+    interval: monthly
+    day: wednesday
+    time: '15:00'
   groups:
     github-actions:
       patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,14 @@
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
-  - package-ecosystem: "pip"
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "weekly"
+- package-ecosystem: pip
+  directory: /
+  schedule:
+    interval: weekly
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    cron: 0 16 12 * *
+  groups:
+    github-actions:
+      patterns:
+      - '*'


### PR DESCRIPTION
## Summary
                
This PR updates the Dependabot configuration to run monthly on the first Wednesday at 3 pm GMT. It also 
updates the Dependabot configuration to include all GitHub Actions workflows.
