### PR TITLE
Add DefectDojo import step to Semgrep workflow

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -32,6 +32,31 @@ jobs:
         with:
           sarif_file: semgrep.sarif
 
+      - name: Import results into DefectDojo
+        if: always()
+        continue-on-error: true
+        env:
+          DEFECTDOJO_URL: ${{ secrets.DEFECTDOJO_URL }}
+          DEFECTDOJO_API_TOKEN: ${{ secrets.DEFECTDOJO_API_TOKEN }}
+        run: |
+          if [ ! -s semgrep.sarif ]; then
+            echo "No semgrep.sarif file found, skipping DefectDojo import"
+            exit 0
+          fi
+          curl -sS -f \
+            -H "Authorization: Token ${DEFECTDOJO_API_TOKEN}" \
+            -F "scan_type=SARIF" \
+            -F "file=@semgrep.sarif" \
+            -F "product_type_name=GitHub" \
+            -F "product_name=${{ github.event.repository.name }}" \
+            -F "engagement_name=CI" \
+            -F "auto_create_context=true" \
+            -F "close_old_findings=true" \
+            -F "deduplication_on_engagement=true" \
+            -F "commit_hash=${{ github.sha }}" \
+            -F "branch_tag=${{ github.head_ref || github.ref_name }}" \
+            "${DEFECTDOJO_URL}/api/v2/reimport-scan/"
+
       - name: Comment findings on PR
         if: github.event_name == 'pull_request' && always()
         env:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -38,6 +38,8 @@ jobs:
         env:
           DEFECTDOJO_URL: ${{ secrets.DEFECTDOJO_URL }}
           DEFECTDOJO_API_TOKEN: ${{ secrets.DEFECTDOJO_API_TOKEN }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          BRANCH_TAG: ${{ github.head_ref || github.ref_name }}
         run: |
           if [ ! -s semgrep.sarif ]; then
             echo "No semgrep.sarif file found, skipping DefectDojo import"
@@ -48,13 +50,13 @@ jobs:
             -F "scan_type=SARIF" \
             -F "file=@semgrep.sarif" \
             -F "product_type_name=GitHub" \
-            -F "product_name=${{ github.event.repository.name }}" \
+            -F "product_name=${REPO_NAME}" \
             -F "engagement_name=CI" \
             -F "auto_create_context=true" \
             -F "close_old_findings=true" \
             -F "deduplication_on_engagement=true" \
             -F "commit_hash=${{ github.sha }}" \
-            -F "branch_tag=${{ github.head_ref || github.ref_name }}" \
+            -F "branch_tag=${BRANCH_TAG}" \
             "${DEFECTDOJO_URL}/api/v2/reimport-scan/"
 
       - name: Comment findings on PR


### PR DESCRIPTION
### **User description**
## Summary
- Adds an "Import results into DefectDojo" step to `.github/workflows/semgrep.yml`, immediately after the existing "Upload SARIF to GitHub Security" step.
- Pushes the Semgrep SARIF output to DefectDojo (`https://defectdojo.smile.id`) via `POST /api/v2/reimport-scan/`, so findings get an aggregated view instead of only living in PR checks.
- Non-blocking: `continue-on-error: true` + `if: always()`, and the step skips gracefully (no failure) if `semgrep.sarif` is missing or empty.
- Auth token is read from `${{ secrets.DEFECTDOJO_API_TOKEN }}` via an `env:` block (not inlined in a header flag); `${{ secrets.DEFECTDOJO_URL }}` is used for the base URL. Both are existing org-wide GitHub Actions secrets already scoped to this repo — no secrets were created or modified.

**SARIF filename in this repo:** this workflow's Semgrep step runs `semgrep scan --config p/security-audit --sarif -o semgrep.sarif`, so the file is `semgrep.sarif` — same name used in the mirrored change below, no adjustment needed. Reviewer: please double check this still matches if the Semgrep step changes in the future.

This mirrors `smileidentity/lambda#4662`, which is currently **open/unmerged** but has been proven working via its own pull_request-triggered CI run.

## Test plan
- [ ] CI run on this PR should show the "Import results into DefectDojo" step executing (non-blocking) after the Semgrep scan.
- [ ] Confirm in DefectDojo that a new/updated scan appears for product `smile-identity-core-python` under engagement `CI` after this PR's CI run.
- [ ] Merge only after human review, per this org's convention.


___

### **PR Type**
Enhancement


___

### **Description**
- Add DefectDojo import step to Semgrep CI workflow

- Pushes SARIF results via reimport-scan API endpoint

- Non-blocking with graceful skip if SARIF missing

- Uses org-wide secrets for authentication and URL


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Semgrep Scan"] --> B["Upload SARIF to GitHub"]
  B --> C["Import to DefectDojo"]
  C --> D["Comment on PR"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>semgrep.yml</strong><dd><code>Add DefectDojo reimport-scan step to CI workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/semgrep.yml

<ul><li>Added a new "Import results into DefectDojo" step after the GitHub <br>SARIF upload<br> <li> Uses <code>curl</code> to POST <code>semgrep.sarif</code> to DefectDojo's reimport-scan API<br> <li> Skips gracefully if <code>semgrep.sarif</code> is missing or empty<br> <li> Configured with <code>continue-on-error: true</code> and <code>if: always()</code> to be <br>non-blocking</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/smile-identity-core-python/pull/232/files#diff-943c91ac8e5085136f071a01d6ad70ffe7beefb141dd4d45c3fc75c52c3c9dbb">+25/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>